### PR TITLE
Fixed Semantic Version in Module Name 

### DIFF
--- a/caption-image_test.go
+++ b/caption-image_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Kardbord/imgflipgo"
+	"github.com/Kardbord/imgflipgo/v2"
 	"github.com/joho/godotenv"
 )
 

--- a/example/example.go
+++ b/example/example.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/Kardbord/imgflipgo"
+	"github.com/Kardbord/imgflipgo/v2"
 	"github.com/joho/godotenv"
 )
 

--- a/get-memes_test.go
+++ b/get-memes_test.go
@@ -3,7 +3,7 @@ package imgflipgo_test
 import (
 	"testing"
 
-	"github.com/Kardbord/imgflipgo"
+	"github.com/Kardbord/imgflipgo/v2"
 )
 
 func TestGetMemesResponse(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Kardbord/imgflipgo
+module github.com/Kardbord/imgflipgo/v2
 
 go 1.17
 


### PR DESCRIPTION
When I updated this module to v2.0.0, I did not realize that I was not following proper conventions for Go module revisions, and therefore v2.0.0 was not usable. This PR aims to fix that.